### PR TITLE
Aws task 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ jspm_packages
 .env
 
 package-lock.json
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/src/bff-service/.ebextensions/nodecommand.config
+++ b/src/bff-service/.ebextensions/nodecommand.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:container:nodejs:
+    NodeCommand: "npm run start"

--- a/src/bff-service/.ebextensions/nodecommand.config
+++ b/src/bff-service/.ebextensions/nodecommand.config
@@ -1,3 +1,0 @@
-option_settings:
-  aws:elasticbeanstalk:container:nodejs:
-    NodeCommand: "npm start"

--- a/src/bff-service/.ebextensions/nodecommand.config
+++ b/src/bff-service/.ebextensions/nodecommand.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:container:nodejs:
+    NodeCommand: "npm start"

--- a/src/bff-service/.ebextensions/nodecommand.config
+++ b/src/bff-service/.ebextensions/nodecommand.config
@@ -1,3 +1,0 @@
-option_settings:
-  aws:elasticbeanstalk:container:nodejs:
-    NodeCommand: "npm run start"

--- a/src/bff-service/.ebextensions/nodecommand.config
+++ b/src/bff-service/.ebextensions/nodecommand.config
@@ -1,3 +1,0 @@
-option_settings:
-aws:elasticbeanstalk:container:nodejs:
-NodeCommand: "npm run start"

--- a/src/bff-service/.ebextensions/nodecommand.config
+++ b/src/bff-service/.ebextensions/nodecommand.config
@@ -1,0 +1,3 @@
+option_settings:
+aws:elasticbeanstalk:container:nodejs:
+NodeCommand: "npm run start"

--- a/src/bff-service/.ebextensions/options.config
+++ b/src/bff-service/.ebextensions/options.config
@@ -1,4 +1,5 @@
 option_settings:
     aws:elasticbeanstalk:application:environment:
         NODE_ENV: 'production'
-        product: 'https://07yjzeof27.execute-api.eu-west-1.amazonaws.com/dev/products/'
+        products: 'https://07yjzeof27.execute-api.eu-west-1.amazonaws.com/dev'
+        cart: "http://battiw-cart-api-develop1.eu-west-1.elasticbeanstalk.com/api/profile"

--- a/src/bff-service/.ebextensions/options.config
+++ b/src/bff-service/.ebextensions/options.config
@@ -1,0 +1,4 @@
+option_settings:
+    aws:elasticbeanstalk:application:environment:
+        NODE_ENV: 'production'
+        product: 'https://07yjzeof27.execute-api.eu-west-1.amazonaws.com/dev/products/'

--- a/src/bff-service/.gitignore
+++ b/src/bff-service/.gitignore
@@ -1,0 +1,38 @@
+# compiled output
+/dist
+node_modules/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS
+.DS_Store
+
+# Tests
+/coverage
+/.nyc_output
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/src/bff-service/Procfile
+++ b/src/bff-service/Procfile
@@ -1,1 +1,0 @@
-web: npm start

--- a/src/bff-service/Procfile
+++ b/src/bff-service/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/src/bff-service/Procfile
+++ b/src/bff-service/Procfile
@@ -1,0 +1,1 @@
+web: node index.js

--- a/src/bff-service/index.js
+++ b/src/bff-service/index.js
@@ -6,10 +6,14 @@ dotenv.config();
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+console.log(`PORT===>`, PORT);
+
 app.use(express.json());
 
 app.all("/*", (res, req) => {
   console.log("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+  console.log(req);
+
   console.log("originalURL===>", req.originalUrl);
   console.log("method===>", req.method);
   console.log("body===>", req.body);

--- a/src/bff-service/index.js
+++ b/src/bff-service/index.js
@@ -9,12 +9,16 @@ const PORT = process.env.PORT || 3001;
 console.log(`PORT===>`, PORT);
 
 app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
 
 app.all("/*", (res, req) => {
   console.log("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
   console.log(req);
+  console.log(`UUUUUUUUUUUURRRRRRRRRRLLLLLLLLLL==>${req.url}`);
 
   console.log("originalURL===>", req.originalUrl);
+  console.log("originalURL1===>", JSON.stringify(req.originalUrl));
+  console.log("originalURL2===>", JSON.parse(req.originalUrl));
   console.log("method===>", req.method);
   console.log("body===>", req.body);
 

--- a/src/bff-service/index.js
+++ b/src/bff-service/index.js
@@ -11,14 +11,12 @@ console.log(`PORT===>`, PORT);
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-app.all("/*", (res, req) => {
+app.all("/*", (req, res) => {
   console.log("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
-  console.log(req);
+  // console.log(req);
   console.log(`UUUUUUUUUUUURRRRRRRRRRLLLLLLLLLL==>${req.url}`);
 
   console.log("originalURL===>", req.originalUrl);
-  console.log("originalURL1===>", JSON.stringify(req.originalUrl));
-  console.log("originalURL2===>", JSON.parse(req.originalUrl));
   console.log("method===>", req.method);
   console.log("body===>", req.body);
 

--- a/src/bff-service/index.js
+++ b/src/bff-service/index.js
@@ -9,13 +9,8 @@ const PORT = process.env.PORT || 3001;
 console.log(`PORT===>`, PORT);
 
 app.use(express.json());
-app.use(express.urlencoded({ extended: false }));
 
 app.all("/*", (req, res) => {
-  console.log("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
-  // console.log(req);
-  console.log(`UUUUUUUUUUUURRRRRRRRRRLLLLLLLLLL==>${req.url}`);
-
   console.log("originalURL===>", req.originalUrl);
   console.log("method===>", req.method);
   console.log("body===>", req.body);
@@ -47,8 +42,7 @@ app.all("/*", (req, res) => {
           const { status, data } = error.response;
           res.status(status).json(data);
         } else {
-          res.status(501).json(`error: error.messagewwwwwwwwwwwwwwwwwww`);
-          // res.status(500).json({ error: error.message });
+          res.status(500).json({ error: error.message });
         }
       });
   } else {

--- a/src/bff-service/index.js
+++ b/src/bff-service/index.js
@@ -1,0 +1,53 @@
+import axios from "axios";
+import express, { response } from "express";
+import dotenv from "dotenv";
+dotenv.config();
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(express.json());
+
+app.all("/*", (res, req) => {
+  console.log("originalURL", originalURL);
+  console.log("method", req.method);
+  console.log("body", req.body);
+
+  const recipient = req.originalURL.split("/")[1];
+  console.log("recipient", recipient);
+
+  const recipientURL = process.env[recipient];
+  console.log("recipientURL", recipientURL);
+
+  if (recipientURL) {
+    const axiosConfig = {
+      method: req.method,
+      url: `${recipientURL}${req.originalURL}`,
+      ...(Object.keys(req.body || {}).length > 0 && { data: req.body }),
+    };
+
+    console.log("axiosConfig", axiosConfig);
+
+    axios(axiosConfig)
+      .then(function (response) {
+        console.log("response from recipient", response.data);
+        res.json(response.data);
+      })
+      .catch((error) => {
+        console.log("some error", JSON.stringify(error));
+
+        if (error.response) {
+          const { status, data } = error.response;
+          res.status(status).json(data);
+        } else {
+          res.status(500).json({ error: error.message });
+        }
+      });
+  } else {
+    res.status(502).json({ error: "Cannot process request" });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Example app listening at http://localhost:${PORT}`);
+});

--- a/src/bff-service/index.js
+++ b/src/bff-service/index.js
@@ -1,5 +1,5 @@
+import express from "express";
 import axios from "axios";
-import express, { response } from "express";
 import dotenv from "dotenv";
 dotenv.config();
 
@@ -9,9 +9,10 @@ const PORT = process.env.PORT || 3001;
 app.use(express.json());
 
 app.all("/*", (res, req) => {
-  console.log("originalURL", req.originalUrl);
-  console.log("method", req.method);
-  console.log("body", req.body);
+  console.log("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+  console.log("originalURL===>", req.originalUrl);
+  console.log("method===>", req.method);
+  console.log("body===>", req.body);
 
   const recipient = req.originalUrl.split("/")[1];
   console.log("recipient", recipient);
@@ -40,8 +41,8 @@ app.all("/*", (res, req) => {
           const { status, data } = error.response;
           res.status(status).json(data);
         } else {
-          console.log("hi");
-          res.status(500).json({ error: error.message });
+          res.status(501).json(`error: error.messagewwwwwwwwwwwwwwwwwww`);
+          // res.status(500).json({ error: error.message });
         }
       });
   } else {

--- a/src/bff-service/index.js
+++ b/src/bff-service/index.js
@@ -9,11 +9,11 @@ const PORT = process.env.PORT || 3001;
 app.use(express.json());
 
 app.all("/*", (res, req) => {
-  console.log("originalURL", originalURL);
+  console.log("originalURL", req.originalUrl);
   console.log("method", req.method);
   console.log("body", req.body);
 
-  const recipient = req.originalURL.split("/")[1];
+  const recipient = req.originalUrl.split("/")[1];
   console.log("recipient", recipient);
 
   const recipientURL = process.env[recipient];
@@ -22,7 +22,7 @@ app.all("/*", (res, req) => {
   if (recipientURL) {
     const axiosConfig = {
       method: req.method,
-      url: `${recipientURL}${req.originalURL}`,
+      url: `${recipientURL}${req.originalUrl}`,
       ...(Object.keys(req.body || {}).length > 0 && { data: req.body }),
     };
 
@@ -40,6 +40,7 @@ app.all("/*", (res, req) => {
           const { status, data } = error.response;
           res.status(status).json(data);
         } else {
+          console.log("hi");
           res.status(500).json({ error: error.message });
         }
       });

--- a/src/bff-service/package.json
+++ b/src/bff-service/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "nodemon index.js"
+    "start": "node index.js"
   },
   "author": "",
   "license": "ISC",

--- a/src/bff-service/package.json
+++ b/src/bff-service/package.json
@@ -4,6 +4,9 @@
   "description": "",
   "main": "index.js",
   "type": "module",
+  "engines": {
+    "node": "14.16.0"
+  },
   "scripts": {
     "start": "node index.js"
   },

--- a/src/bff-service/package.json
+++ b/src/bff-service/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "engines": {
-    "node": "14.16.0"
+    "node": "16.14.2"
   },
   "scripts": {
     "start": "node index.js"

--- a/src/bff-service/package.json
+++ b/src/bff-service/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bff-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "nodemon index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.24.0",
+    "cors": "^2.8.5",
+    "dotenv": "^10.0.0",
+    "express": "^4.17.1",
+    "node-cache": "^5.1.2",
+    "nodemon": "^2.0.14"
+  }
+}

--- a/src/bff-service/package.json
+++ b/src/bff-service/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "nodemon index.js"
+    "start": "nodemon index.js"
   },
   "author": "",
   "license": "ISC",

--- a/src/product-servis/.gitignore copy
+++ b/src/product-servis/.gitignore copy
@@ -1,9 +1,0 @@
-# package directories
-node_modules
-jspm_packages
-
-# Serverless directories
-.serverless
-.env
-
-package-lock.json


### PR DESCRIPTION
1. Task 9: https://github.com/EPAM-JS-Competency-center/cloud-development-course-initial/blob/main/9_backend_for_frontend/task.md
2.  Screenshot
3.  Deployment:
[AWS-shop-BE](https://07yjzeof27.execute-api.eu-west-1.amazonaws.com/dev/products)
[AWS-shop-FE](https://d1zdbonze7xn8z.cloudfront.net)
4.  Done 01.08.2022 / deadline 15/08/2022
5.  Score 5/7


Endpoints:
GET - https://07yjzeof27.execute-api.eu-west-1.amazonaws.com/dev/products
GET - https://07yjzeof27.execute-api.eu-west-1.amazonaws.com/dev/products/{productId}
POST - https://07yjzeof27.execute-api.eu-west-1.amazonaws.com/dev/products
endpoint to get signedUrl
GET - https://9lyka8f6d9.execute-api.eu-west-1.amazonaws.com/dev/import
Cart:
http://battiw-cart-api-develop1.eu-west-1.elasticbeanstalk.com
BFF:
http://battiw-bff-api-developbff.eu-west-1.elasticbeanstalk.com
call for products
http://battiw-bff-api-developbff.eu-west-1.elasticbeanstalk.com/products
call for cart:
http://battiw-bff-api-developbff.eu-west-1.elasticbeanstalk.com/cart

-Evaluation criteria (5/5)
- [x] a working and correct Express application should be in the bff-service folder. Reviewer can start this application locally with any valid configuration in the .env file and this application should works as described in the Task 9.1 (+3)
- [x] the BFF Service should be deployed with Elastic Beanstalk. The BFF Service call should be redirected to the appropriate service : Product Service or Cart Service. The response from the BFF Service should be the same as if Product Service or Cart Service services were called directly. (+2)

Additional (optional) tasks (0/2)
- [-] add a cache at the BFF Service level for a request to the getProductsList lambda function of the Product Service. The cache should expire in 2 minutes. (+1)
- [-] Use NestJS to create BFF Service instead of Express (+1)